### PR TITLE
Moved jacoco plugin out of pluginManagement section

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,34 +71,36 @@
                         <update>true</update>
                     </configuration>
                 </plugin>
-                <plugin>
-                    <groupId>org.jacoco</groupId>
-                    <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.6</version>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>prepare-agent</goal>
-                            </goals>
-                        </execution>
-                        <execution>
-                            <id>report</id>
-                            <phase>test</phase>
-                            <goals>
-                                <goal>report</goal>
-                            </goals>
-                            <configuration>
-                                <excludes>
-                                    <exclude>com/revature/quizzard/daos/*</exclude>
-                                    <exclude>com/revature/quizzard/models/*</exclude>
-                                    <exclude>com/revature/quizzard/exceptions/*</exclude>
-                                </excludes>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.6</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>com/revature/quizzard/daos/*</exclude>
+                                <exclude>com/revature/quizzard/models/*</exclude>
+                                <exclude>com/revature/quizzard/exceptions/*</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
 </project>


### PR DESCRIPTION
After having issues generating a report with jacoco, I found that moving the plugin out of the plugin management section was the solution. This SO top answer describes it: https://stackoverflow.com/questions/36304793/jacoco-with-maven-missing-execution-data-file